### PR TITLE
Fix failed compilation with clang

### DIFF
--- a/PortAnonymizer.cpp
+++ b/PortAnonymizer.cpp
@@ -67,7 +67,7 @@ void PortAnonymizer::WriteMappings(const char* filename) const
 		}
 
 	for ( uint16_t i = 0; i < NUM_PORTS; ++i )
-		fprintf(f, "%"PRIu16": %"PRIu16"\n", i, reverse_map[i]);
+		fprintf(f, "%" PRIu16 ": %" PRIu16 "\n", i, reverse_map[i]);
 
 	fclose(f);
 	}

--- a/main.cpp
+++ b/main.cpp
@@ -270,9 +270,9 @@ static void reverse_port(const string& port, const uint8_t key[34],
 		}
 
 	if ( reverse )
-		printf("%"PRIu16"\n", ntohs(l4anon.DeAnonymize(htons(port_h))));
+		printf("%" PRIu16 "\n", ntohs(l4anon.DeAnonymize(htons(port_h))));
 	else
-		printf("%"PRIu16"\n", ntohs(l4anon.Anonymize(htons(port_h))));
+		printf("%" PRIu16 "\n", ntohs(l4anon.Anonymize(htons(port_h))));
 	}
 
 int main(int argc, char** argv)


### PR DESCRIPTION
`error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]`